### PR TITLE
Refactor FastAPI lifespan handling and update schema model usage

### DIFF
--- a/app/crud/orders.py
+++ b/app/crud/orders.py
@@ -1,14 +1,16 @@
 from sqlalchemy.orm import Session
+
 from app.models import orders as models
 from app.schemas import orders as orders_schemas
 
+
 def create_orders(db: Session, orders: orders_schemas.OrdersCreate):
-    db_orders = models.Orders(**orders.dict())
+    db_orders = models.Orders(**orders.model_dump())
     db.add(db_orders)
     db.commit()
     db.refresh(db_orders)
     return db_orders
 
+
 def get_orders(db: Session, skip: int = 0, limit: int = 10):
     return db.query(models.Orders).offset(skip).limit(limit).all()
-

--- a/app/crud/product.py
+++ b/app/crud/product.py
@@ -1,14 +1,17 @@
 from sqlalchemy.orm import Session
+
 from app.models import product as models
 from app.schemas import product as product_schemas
 
-# Create new Product
+
+# Create a new Product
 def create_product(db: Session, product: product_schemas.ProductCreate):
     db_product = models.Product(**product.model_dump())
     db.add(db_product)
     db.commit()
     db.refresh(db_product)
     return db_product
+
 
 def get_products(db: Session, skip: int = 0, limit: int = 10):
     return db.query(models.Product).offset(skip).limit(limit).all()

--- a/app/crud/weed.py
+++ b/app/crud/weed.py
@@ -1,9 +1,11 @@
 from sqlalchemy.orm import Session
+
 from app.models import weed as models
 from app.schemas import weed as weed_schemas
 
+
 def create_weed(db: Session, weed: weed_schemas.WeedCreate):
-    db_weed = models.Weed(**weed.dict())
+    db_weed = models.Weed(**weed.model_dump())
     db.add(db_weed)
     db.commit()
     db.refresh(db_weed)


### PR DESCRIPTION
- Replaced `on_startup` with an `asynccontextmanager` for managing the FastAPI lifespan.
- Updated schema usage from `.dict()` to `.model_dump()` across CRUD operations.
- Minor formatting and comment adjustments.