### PR TITLE
Add optional 'slug' field to Product schema and model

### DIFF
--- a/app/models/product.py
+++ b/app/models/product.py
@@ -10,6 +10,7 @@ class Product(Base):
     name = Column(String(255), nullable=False)
     price = Column(Float, nullable=False)
     w_id = Column(Integer, ForeignKey("weed.w_id"), nullable=False)
+    slug = Column(String(255), nullable=True)
 
 
 class ProductBase(BaseModel):
@@ -18,3 +19,4 @@ class ProductBase(BaseModel):
     )
     price: float = Field(..., gt=0, description="Price must be greater than 0")
     w_id: int
+    slug: str = Field(None, description="Path to the product picture")

--- a/app/schemas/product.py
+++ b/app/schemas/product.py
@@ -7,6 +7,7 @@ class ProductBase(BaseModel):
     name: str
     price: float
     w_id: int
+    slug: Optional[str] = None
 
 
 class ProductCreate(ProductBase):
@@ -16,6 +17,7 @@ class ProductCreate(ProductBase):
 class ProductUpdate(BaseModel):
     name: Optional[str]
     price: Optional[float]
+    slug: Optional[str]
 
 
 class Product(ProductBase):


### PR DESCRIPTION
The 'slug' field has been introduced as an optional attribute in the Product schema and database model. This allows storing an additional identifier, such as a URL-friendly path for the product, enhancing flexibility and usability.