### PR TITLE
Add product retrieval by ID functionality

### DIFF
--- a/app/crud/product.py
+++ b/app/crud/product.py
@@ -44,6 +44,20 @@ def get_products(db: Session, skip: int = 0, limit: int = 10):
     return db.query(models.Product).offset(skip).limit(limit).all()
 
 
+def get_product_by_id(db: Session, p_id: int):
+    try:
+        if not isinstance(p_id, int):
+            raise ValueError("p_id must be an integer")
+        product = db.query(models.Product).filter(models.Product.p_id == p_id).first()
+        if product is None:
+            raise ValueError(f"Product with id {p_id} does not exist")
+        return product
+    except ValueError:
+        raise
+    except Exception as e:
+        raise RuntimeError(f"Failed to get product by id: {str(e)}")
+
+
 # Update an existing product
 def update_products(db: Session, p_id: int, update_data: product_schemas.ProductUpdate):
     try:

--- a/app/models/orders.py
+++ b/app/models/orders.py
@@ -7,4 +7,5 @@ class Orders(Base):
     __tablename__ = "orders"
     o_id = Column(Integer, primary_key=True, autoincrement=True)
     c_id = Column(Integer, ForeignKey("customer.c_id"), nullable=False)
+    p_id = Column(Integer, ForeignKey("product.p_id"), nullable=False)
     amount = Column(Float, nullable=False)

--- a/app/routers/product.py
+++ b/app/routers/product.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.crud import product as crud
@@ -21,6 +22,16 @@ def create_products(
 @router.get("/products/", response_model=list[schemas.Product])
 def get_products(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
     return crud.get_products(db=db, skip=skip, limit=limit)
+
+@router.get("/products/{product_id}", response_model=schemas.Product)
+def get_product_by_id(product_id: int, db: Session = Depends(get_db)):
+    try:
+        return crud.get_product_by_id(db=db, p_id=product_id)
+    except SQLAlchemyError:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error occured while getting product id."
+        )
 
 
 @router.patch("/products/{product_id}", response_model=schemas.Product)

--- a/app/routers/weed.py
+++ b/app/routers/weed.py
@@ -54,7 +54,7 @@ def get_weed_by_id(weed_id: int, db: Session = Depends(get_db)):
     except SQLAlchemyError:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Database error occurred while getting weed.",
+            detail="Database error occurred while getting weed id.",
         )
 
 


### PR DESCRIPTION
Introduced the `get_product_by_id` function in the CRUD layer to fetch a product by its ID with error handling. Updated the `/products/{product_id}` endpoint in the router to utilize this function.