### PR TITLE
Move customer registration endpoint to auth router

### DIFF
--- a/app/routers/customer.py
+++ b/app/routers/customer.py
@@ -1,35 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.crud import customer as crud
-from app.models import customer as models
 from app.schemas import customer as schemas
 from app.utils.database import get_db
-from app.utils.password import password_hash
 
 router = APIRouter()
-
-
-@router.post("/customer/", response_model=schemas.Customer)
-def create_customer(customer: schemas.CustomerCreate, db: Session = Depends(get_db)):
-    # Check for existing email
-    existing = (
-        db.query(models.Customer)
-        .filter(models.Customer.email == customer.email)
-        .first()
-    )
-    if existing:
-        raise HTTPException(status_code=400, detail="Email already registered")
-
-    hashed_password = password_hash(customer.password)
-    customer.password = hashed_password
-    new_customer = models.Customer(**customer.model_dump())
-    db.add(new_customer)
-    db.commit()
-    db.refresh(new_customer)
-    return new_customer
-
-    # return crud.create_customer(db=db, customer=customer)
 
 
 @router.get("/customer/", response_model=list[schemas.Customer])


### PR DESCRIPTION
Moved customer creation logic from customer router to a new `/register` endpoint in the auth router. This consolidates authentication-related functionalities and removes redundant code from the customer router.