### PR TITLE
Add customer self-service endpoints and enhance schema documentation

### DIFF
--- a/app/crud/customer.py
+++ b/app/crud/customer.py
@@ -59,3 +59,25 @@ def get_customer_by_id(db: Session, customer_id: int):
     if customer and customer.is_admin is None:
         customer.is_admin = False
     return customer
+
+
+def update_customer(db: Session, customer_id: int, customer_data: customer_schemas.CustomerUpdate):
+    """
+    Update a customer's information.
+
+    Args:
+        db (Session): Database session.
+        customer_id (int): ID of the customer to update.
+        customer_data (customer_schemas.CustomerUpdate): New customer data.
+
+    Returns:
+        models.Customer: The updated customer, or None if not found.
+    """
+    db_customer = db.query(models.Customer).filter(models.Customer.c_id == customer_id).first()
+    if db_customer:
+        update_data = customer_data.model_dump()
+        for key, value in update_data.items():
+            setattr(db_customer, key, value)
+        db.commit()
+        db.refresh(db_customer)
+    return db_customer

--- a/app/routers/customer.py
+++ b/app/routers/customer.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.crud import customer as crud
 from app.models.customer import Customer
-from app.routers.oauth2 import get_admin_user
+from app.routers.oauth2 import get_admin_user, get_current_user
 from app.schemas import customer as schemas
 from app.utils.database import get_db
 
@@ -35,30 +35,121 @@ def get_customers(
     return crud.get_customer(db=db, skip=skip, limit=limit)
 
 
+@router.get("/customers/me", response_model=schemas.Customer)
+def get_customer_me(current_user: Customer = Depends(get_current_user)):
+    """
+    Get the current logged-in customer's information.
+
+    This endpoint returns the data of the currently authenticated customer.
+    For regular users, sensitive fields (id and is_admin) are excluded.
+    For admin users, all fields are included.
+
+    Args:
+        current_user (Customer): The authenticated customer.
+
+    Returns:
+        schemas.Customer or schemas.CustomerResponse: The current customer's data.
+    """
+    # Use different response models based on user role
+    if current_user.is_admin:
+        # Use the original response_model defined in the decorator
+        return current_user
+    else:
+        # Override the response_model for non-admin users
+        from fastapi.responses import JSONResponse
+        return JSONResponse(content={
+            "name": current_user.name,
+            "address": current_user.address,
+            "email": current_user.email
+        })
+
+
 @router.get("/customers/{customer_id}", response_model=schemas.Customer)
 def get_customer_by_id(
     customer_id: int, 
     db: Session = Depends(get_db),
-    current_user: Customer = Depends(get_admin_user)
+    current_user: Customer = Depends(get_current_user)
 ):
     """
     Get a customer by ID.
 
     This endpoint returns a single customer by its ID.
-    Requires admin privileges.
+    Regular users can only access their own data, while admins can access any customer's data.
+    For regular users, sensitive fields (id and is_admin) are excluded.
+    For admin users, all fields are included.
 
     Args:
         customer_id (int): ID of the customer to retrieve.
         db (Session, optional): Database session. Defaults to Depends(get_db).
-        current_user (Customer): The authenticated admin user.
+        current_user (Customer): The authenticated user.
 
     Returns:
-        schemas.Customer: The requested customer.
+        schemas.Customer or schemas.CustomerResponse: The requested customer.
 
     Raises:
-        HTTPException: If the customer is not found.
+        HTTPException: If the customer is not found or if a non-admin user tries to access another user's data.
     """
+    # Check if user is trying to access their own data or if they're an admin
+    if current_user.c_id != customer_id and not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to access this customer's data"
+        )
+
     db_customer = crud.get_customer_by_id(db=db, customer_id=customer_id)
     if db_customer is None:
         raise HTTPException(status_code=404, detail="Customer not found")
-    return db_customer
+
+    # Use different response models based on user role
+    if current_user.is_admin:
+        # Use the original response_model defined in the decorator
+        return db_customer
+    else:
+        # Override the response_model for non-admin users
+        from fastapi.responses import JSONResponse
+        return JSONResponse(content={
+            "name": db_customer.name,
+            "address": db_customer.address,
+            "email": db_customer.email
+        })
+
+
+@router.patch("/customers/me", response_model=schemas.Customer)
+def update_customer_me(
+    customer_data: schemas.CustomerUpdate,
+    db: Session = Depends(get_db),
+    current_user: Customer = Depends(get_current_user)
+):
+    """
+    Update the current customer's information.
+
+    This endpoint allows a logged-in customer to update their name and address.
+    For regular users, sensitive fields (id and is_admin) are excluded from the response.
+    For admin users, all fields are included in the response.
+
+    Args:
+        customer_data (schemas.CustomerUpdate): New customer data (name and address).
+        db (Session, optional): Database session. Defaults to Depends(get_db).
+        current_user (Customer): The authenticated customer.
+
+    Returns:
+        schemas.Customer or schemas.CustomerResponse: The updated customer data.
+    """
+    updated_customer = crud.update_customer(
+        db=db, 
+        customer_id=current_user.c_id, 
+        customer_data=customer_data
+    )
+
+    # Use different response models based on user role
+    if current_user.is_admin:
+        # Use the original response_model defined in the decorator
+        return updated_customer
+    else:
+        # Override the response_model for non-admin users
+        from fastapi.responses import JSONResponse
+        return JSONResponse(content={
+            "name": updated_customer.name,
+            "address": updated_customer.address,
+            "email": updated_customer.email
+        })

--- a/app/routers/product.py
+++ b/app/routers/product.py
@@ -88,7 +88,7 @@ def create_products(
 
 
 @router.get("/products/", response_model=list[schemas.Product])
-def get_products(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
+def get_products(skip: int = 0, limit: int = 20, db: Session = Depends(get_db)):
     """
     Get a list of products with pagination.
 
@@ -96,7 +96,7 @@ def get_products(skip: int = 0, limit: int = 10, db: Session = Depends(get_db)):
 
     Args:
         skip (int, optional): Number of products to skip. Defaults to 0.
-        limit (int, optional): Maximum number of products to return. Defaults to 10.
+        limit (int, optional): Maximum number of products to return. Defaults to 20.
         db (Session, optional): Database session. Defaults to Depends(get_db).
 
     Returns:

--- a/app/schemas/customer.py
+++ b/app/schemas/customer.py
@@ -77,3 +77,44 @@ class CustomerLogin(BaseModel):
     """
     email: EmailStr
     password: str
+
+
+class CustomerUpdate(BaseModel):
+    """
+    Schema for updating customer data.
+
+    Contains only the fields that can be updated by the customer.
+
+    Attributes:
+        name (str): Customer's full name.
+        address (str): Customer's physical address.
+    """
+    name: str
+    address: str
+
+    model_config = {
+        "from_attributes": True,
+        "populate_by_name": True
+    }
+
+
+class CustomerResponse(BaseModel):
+    """
+    Schema for customer response data for regular users.
+
+    Contains only the non-sensitive fields that regular users should see.
+    Does not include id and is_admin fields which should only be visible to admins.
+
+    Attributes:
+        name (str): Customer's full name.
+        address (str): Customer's physical address.
+        email (str): Customer's email address.
+    """
+    name: str
+    address: str
+    email: str
+
+    model_config = {
+        "from_attributes": True,
+        "populate_by_name": True
+    }

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -45,9 +45,11 @@ The ShinyLeaves API is organized around the following resources:
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | /api/customers/ | Get a list of customers with pagination |
-| GET | /api/customers/{customer_id} | Get a customer by ID |
+| GET | /api/customers/{customer_id} | Get a customer by ID (users can access their own data, admins can access any customer's data) |
+| GET | /api/customers/me | Get the current logged-in customer's information |
 | POST | /api/customers/ | Create a new customer |
 | PATCH | /api/customers/{customer_id} | Update a customer |
+| PATCH | /api/customers/me | Update the current customer's name and address |
 | DELETE | /api/customers/{customer_id} | Delete a customer |
 
 ### Authentication
@@ -204,6 +206,75 @@ Authorization: Bearer <your_token>
 **Response:**
 ```
 204 No Content
+```
+
+### Get Customer by ID
+
+**Request:**
+```http
+GET /api/customers/1 HTTP/1.1
+Host: localhost:8000
+Authorization: Bearer <your_token>
+```
+
+**Response:**
+```json
+{
+  "id": 1,
+  "name": "John Smith",
+  "address": "123 Main Street, City, Country",
+  "email": "john@example.com",
+  "password": "hashed_password",
+  "is_admin": false
+}
+```
+
+### Get Current Customer
+
+**Request:**
+```http
+GET /api/customers/me HTTP/1.1
+Host: localhost:8000
+Authorization: Bearer <your_token>
+```
+
+**Response:**
+```json
+{
+  "id": 1,
+  "name": "John Smith",
+  "address": "123 Main Street, City, Country",
+  "email": "john@example.com",
+  "password": "hashed_password",
+  "is_admin": false
+}
+```
+
+### Update Current Customer
+
+**Request:**
+```http
+PATCH /api/customers/me HTTP/1.1
+Host: localhost:8000
+Content-Type: application/json
+Authorization: Bearer <your_token>
+
+{
+  "name": "John Smith",
+  "address": "123 New Street, City, Country"
+}
+```
+
+**Response:**
+```json
+{
+  "id": 1,
+  "name": "John Smith",
+  "address": "123 New Street, City, Country",
+  "email": "john@example.com",
+  "password": "hashed_password",
+  "is_admin": false
+}
 ```
 
 ## Rate Limiting


### PR DESCRIPTION
Introduced `/customers/me` endpoints for retrieving and updating the logged-in customer's data. Updated schemas to include `CustomerUpdate` and `CustomerResponse` for better clarity and role-specific responses. Adjusted product pagination default and expanded API documentation with detailed examples.